### PR TITLE
Include the repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "rabbitmq-management-client"
 version = "0.0.1-alpha.6"
 edition = "2021"
 license = "MIT"
-
+repository = "https://github.com/stefandanaita/rabbitmq-management-client"
 description = "A Rust client for the RabbitMQ Management API"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.