### PR TITLE
Add support for `arguments` field in `GET /api/queues/my_vhost/my_queue/bindings`

### DIFF
--- a/src/api/binding.rs
+++ b/src/api/binding.rs
@@ -210,6 +210,7 @@ pub struct RabbitMqBinding {
     pub destination_type: RabbitMqBindingDestinationType,
     pub routing_key: String,
     pub properties_key: String,
+    pub arguments: HashMap<String, String>,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
Verified the field was arguments as a dictionary from https://rawcdn.githack.com/rabbitmq/rabbitmq-server/v3.12.1/deps/rabbitmq_management/priv/www/api/index.html

and by 
```
curl -u guest:guest http://localhost:41007/api/queues/%2F/my_queue/bindings | jq
```